### PR TITLE
Release vlang/v for Linux/ARM64

### DIFF
--- a/.github/workflows/binary_artifact.yml
+++ b/.github/workflows/binary_artifact.yml
@@ -38,7 +38,40 @@ jobs:
       with:
         name: linux-binary
         path: ./v
-
+  build-linux-arm64:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        compiler: [gcc]
+    env:
+      img: quay.io/pypa/manylinux2014_aarch64
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+    - name: Compile
+      env:
+        CC: ${{ matrix.compiler }}
+      run: |
+         docker run --platform=linux/arm64 --rm -v `pwd`:`pwd` -w `pwd` ${{ env.img }} /bin/bash -c "make -j4 && ./v -cc $CC -o v -prod cmd/v && ./v -prod cmd/tools/vup.v && ./v -prod cmd/tools/vdoctor.v"
+    - name: Create artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: linux_arm64
+        path: |
+          .
+          ./cmd/tools/vup
+          ./cmd/tools/vdoctor
+          !./.git
+          !./vc
+          !./v_old
+    - name: Create binary only artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: linux_arm64-binary
+        path: ./v
   build-macos:
     runs-on: macos-latest
     strategy:
@@ -99,7 +132,7 @@ jobs:
 
   release:
     name: Create Github Release
-    needs: [build-linux, build-windows, build-macos]
+    needs: [build-linux-arm64, build-linux, build-windows, build-macos]
     runs-on: ubuntu-20.04
     steps:
     - name: Get short tag name
@@ -124,7 +157,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        version: [linux, macos, windows]
+        version: [linux_arm64, linux, macos, windows]
     steps:
     - uses: actions/checkout@v1
     - name: Fetch artifacts


### PR DESCRIPTION
**Hi**

**Package Owner:** Rahul Aggarwal

**PR change Details:**

**1. Patch Details:** Following file has been modified :

- **binary_artifact.yml:**   Added 'build-linux-arm64' job with the QEMU support to the binary_artifact.yml file, to release vlang/v Linux/ARM64 zip archive.

**2. Testing Detail:**

- Please find my GA testing jobs here: <https://github.com/rahulgit-ps/v/actions/runs/560028436>
- Please find my forked repo Github Releases with ARM64 zip archive here: <https://github.com/rahulgit-ps/v/releases>
- I have tested the package by downloading my uploaded ARM64 zip archive shared above, and tested as below:
~~~
$  ./v run examples/hello_world.v
Hello, World!

$ /workspace/rough/v/v up
Updating V...
Current V version:
V 0.2.2 67c6f24, timestamp: 2021-02-12 03:37:31 +0100
~~~

**3. PR Description:** Here is my commit message :

_Added 'build-linux-arm64' job with the QEMU support to the binary_artifact.yml file, to release vlang/v Linux/ARM64 zip archive._

_Signed-off-by: odidev <odidev@puresoftware.com>_

**4. Reviewer:** Akhand Pratap Singh

**Thanks
Rahul Aggarwal**